### PR TITLE
Change prophecy dependency to allow 1.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "phpunit/php-code-coverage": "~2.0,>=2.0.11",
         "phpunit/php-timer": "~1.0",
         "phpunit/phpunit-mock-objects": "~2.3",
-        "phpspec/prophecy": "~1.3.1",
+        "phpspec/prophecy": "~1.3,>=1.3.1",
         "symfony/yaml": "~2.1|~3.0",
         "sebastian/comparator": "~1.1",
         "sebastian/diff": "~1.2",


### PR DESCRIPTION
Prophecy 1.4.0 is released and doesn't contain any BC breaks, currently PHPUnit 4.5.0 and PhpSpec  2.2.0-beta cannot both be present in a project because the latter depends on Prophecy 1.4.0
